### PR TITLE
P81-113713 chore(security): pin 3rd party actions to SHA commits [skip actions]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,13 +16,13 @@ jobs:
         go: ["1.17.x", "1.18.x"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: License check
         run: ./scripts/licensecheck.sh
 
       - name: Go installation
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: ${{ matrix.go }}
 


### PR DESCRIPTION
## Summary
- Pin 3rd party GitHub Actions to SHA commit hashes for supply-chain security
- Set internal actions (`perimeter-81/actions/actions/...`) to `@v1` with `# zizmor: ignore[unpinned-uses]`
- Prevents supply-chain attacks via tag mutation

Part of epic [P81-113387](https://perimeter81.atlassian.net/browse/P81-113387)

## Review guidelines

### 1. Internal actions must be pinned to `@v1`

```yaml
# ✅ Correct
uses: perimeter-81/actions/actions/aws/assume_role_v2@v1 # zizmor: ignore[unpinned-uses]

# ❌ Wrong — points to @main or feature branch
uses: perimeter-81/actions/actions/aws/assume_role@main # zizmor: ignore[unpinned-uses]
```

### 2. 3rd party actions must be pinned to full SHA with version comment

```yaml
# ✅ Correct
uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

# ❌ Wrong — version tag instead of SHA
uses: actions/checkout@v4

# ❌ Wrong — SHA without version comment
uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
```

### Quick validation
```bash
# 3rd party still using version tags
grep -rn "uses:" .github/workflows/ | grep -v "perimeter-81/" | grep "@v"

# 3rd party missing version comment
grep -rn "uses:" .github/workflows/ | grep "@[a-f0-9]\{40\}" | grep -v "#"

# Internal actions not pinned to @v1
grep -rn "uses:.*perimeter-81/actions/actions/" .github/workflows/ | grep -v "@v1"
```

## Test plan
- [ ] Verify workflow files have correct SHA pins with version comments
- [ ] Verify internal actions point to `@v1` with zizmor comment

[P81-113387]: https://perimeter81.atlassian.net/browse/P81-113387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ