### PR TITLE
[skip actions] P81-120874 Migrate to self-hosted runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ACTIONS_RUNNER }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Jira: https://perimeter81.atlassian.net/browse/P81-120874

## Changes

Migrated all workflow `runs-on` values to use `${{ vars.ACTIONS_RUNNER }}`.

Runner selected because: repository does not require Docker-in-Docker.

## Modified workflow files

- `.github/workflows/main.yml`

---
Co-authored-by: Claude (claude-sonnet-4-6)